### PR TITLE
Initial code from Velato

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,21 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+t1_iy = "t1_iy"
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+# /.git isn't in .gitignore, because git never tracks it.
+# Typos doesn't know that, though.
+extend-exclude = ["/.git"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,82 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "interpoli"
 version = "0.1.0"
+dependencies = [
+ "keyframe",
+ "kurbo",
+ "peniko",
+]
+
+[[package]]
+name = "keyframe"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60708bf7981518d09095d6f5673ce5cf6a64f1e0d9708b554f670e6d9d2bd9a9"
+dependencies = [
+ "mint",
+ "num-traits",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5aa9f0f96a938266bdb12928a67169e8d22c6a786fda8ed984b85e6ba93c3c"
+dependencies = [
+ "arrayvec",
+ "libm",
+ "mint",
+ "smallvec",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "peniko"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c28d7294093837856bb80ad191cc46a2fcec8a30b43b7a3b0285325f0a917a9"
+dependencies = [
+ "kurbo",
+ "smallvec",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ rust-version = "1.75"
 
 [features]
 default = ["std"]
-std = []
-libm = []
+std = ["kurbo/std", "peniko/std"]
+libm = ["kurbo/libm", "peniko/libm"]
+mint = ["keyframe/mint_types", "kurbo/mint"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,6 +25,9 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
+keyframe = { version = "1.1.1", default-features = false }
+kurbo = { version = "0.11", default-features = false }
+peniko = { version = "0.1.1", default-features = false }
 
 [lints]
 rust.unsafe_code = "forbid"
@@ -33,20 +37,15 @@ rust.non_ascii_idents = "forbid"
 rust.non_local_definitions = "forbid"
 rust.unsafe_op_in_unsafe_fn = "forbid"
 
-rust.elided_lifetimes_in_paths = "warn"
 rust.let_underscore_drop = "warn"
 rust.missing_debug_implementations = "warn"
-rust.missing_docs = "warn"
-rust.single_use_lifetimes = "warn"
 rust.trivial_numeric_casts = "warn"
 rust.unexpected_cfgs = "warn"
 rust.unit_bindings = "warn"
 rust.unnameable_types = "warn"
-rust.unreachable_pub = "warn"
 rust.unused_import_braces = "warn"
 rust.unused_lifetimes = "warn"
 rust.unused_macro_rules = "warn"
-rust.unused_qualifications = "warn"
 rust.variant_size_differences = "warn"
 
 clippy.allow_attributes_without_reason = "warn"
@@ -65,12 +64,19 @@ clippy.missing_errors_doc = "warn"
 clippy.missing_fields_in_debug = "warn"
 clippy.missing_panics_doc = "warn"
 clippy.partial_pub_fields = "warn"
-clippy.return_self_not_must_use = "warn"
 clippy.same_functions_in_if_condition = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 clippy.shadow_unrelated = "warn"
 clippy.should_panic_without_expect = "warn"
 clippy.todo = "warn"
 clippy.unseparated_literal_suffix = "warn"
-clippy.use_self = "warn"
 clippy.wildcard_imports = "warn"
+
+# TODO: Enable these and move them back above.
+# clippy.return_self_not_must_use = "warn"
+# clippy.use_self = "warn"
+# rust.elided_lifetimes_in_paths = "warn"
+# rust.missing_docs = "warn"
+# rust.single_use_lifetimes = "warn"
+# rust.unreachable_pub = "warn"
+# rust.unused_qualifications = "warn"

--- a/src/animated.rs
+++ b/src/animated.rs
@@ -1,0 +1,423 @@
+// Copyright 2024 the Interpoli Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*!
+Representations of animated values.
+*/
+
+use super::*;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[allow(unused_imports)]
+use kurbo::common::FloatFuncs as _;
+use kurbo::PathEl;
+
+#[derive(Clone, Debug)]
+pub enum Position {
+    Value(Value<Point>),
+    SplitValues((Value<f64>, Value<f64>)),
+}
+
+/// Animated affine transformation.
+#[derive(Clone, Debug)]
+pub struct Transform {
+    /// Anchor point.
+    pub anchor: Value<Point>,
+    /// Translation.
+    pub position: Position,
+    /// Rotation angle.
+    pub rotation: Value<f64>,
+    /// Scale factor.
+    pub scale: Value<Vec2>,
+    /// Skew factor.
+    pub skew: Value<f64>,
+    /// Skew angle.
+    pub skew_angle: Value<f64>,
+}
+
+impl Transform {
+    /// Returns true if the transform is fixed.
+    pub fn is_fixed(&self) -> bool {
+        self.anchor.is_fixed()
+            && match &self.position {
+                Position::Value(value) => value.is_fixed(),
+                Position::SplitValues((x_value, y_value)) => {
+                    x_value.is_fixed() && y_value.is_fixed()
+                }
+            }
+            && self.rotation.is_fixed()
+            && self.scale.is_fixed()
+            && self.skew.is_fixed()
+            && self.skew_angle.is_fixed()
+    }
+
+    /// Evaluates the transform at the specified frame.
+    pub fn evaluate(&self, frame: f64) -> Affine {
+        let anchor = self.anchor.evaluate(frame);
+        let position = match &self.position {
+            Position::Value(value) => value.evaluate(frame),
+            Position::SplitValues((x_value, y_value)) => kurbo::Point {
+                x: x_value.evaluate(frame),
+                y: y_value.evaluate(frame),
+            },
+        };
+        let rotation = self.rotation.evaluate(frame);
+        let scale = self.scale.evaluate(frame);
+        let skew = self.skew.evaluate(frame);
+        let skew_angle = self.skew_angle.evaluate(frame);
+        let skew_matrix = if skew != 0.0 {
+            const SKEW_LIMIT: f64 = 85.0;
+            let skew = -skew.clamp(-SKEW_LIMIT, SKEW_LIMIT);
+            let skew = skew.to_radians();
+            let angle = skew_angle.to_radians();
+            Affine::rotate(-angle) * Affine::skew(skew.tan(), 0.0) * Affine::rotate(angle)
+        } else {
+            Affine::IDENTITY
+        };
+        Affine::translate((position.x, position.y))
+            * Affine::rotate(rotation.to_radians())
+            * skew_matrix
+            * Affine::scale_non_uniform(scale.x / 100.0, scale.y / 100.0)
+            * Affine::translate((-anchor.x, -anchor.y))
+    }
+
+    /// Converts the animated value to its model representation.
+    pub fn into_model(self) -> super::Transform {
+        if self.is_fixed() {
+            super::Transform::Fixed(self.evaluate(0.0))
+        } else {
+            super::Transform::Animated(self)
+        }
+    }
+}
+
+/// Animated ellipse.
+#[derive(Clone, Debug)]
+pub struct Ellipse {
+    /// True if the ellipse should be drawn in CCW order.
+    pub is_ccw: bool,
+    /// Position of the ellipse.
+    pub position: Value<Point>,
+    /// Size of the ellipse.
+    pub size: Value<Size>,
+}
+
+impl Ellipse {
+    pub fn is_fixed(&self) -> bool {
+        self.position.is_fixed() && self.size.is_fixed()
+    }
+
+    pub fn evaluate(&self, frame: f64) -> kurbo::Ellipse {
+        let position = self.position.evaluate(frame);
+        let size = self.size.evaluate(frame);
+        let radii = (size.width * 0.5, size.height * 0.5);
+        kurbo::Ellipse::new(position, radii, 0.0)
+    }
+}
+
+/// Animated rounded rectangle.
+#[derive(Clone, Debug)]
+pub struct Rect {
+    /// True if the rect should be drawn in CCW order.
+    pub is_ccw: bool,
+    /// Position of the rectangle.
+    pub position: Value<Point>,
+    /// Size of the rectangle.
+    pub size: Value<Size>,
+    /// Radius of the rectangle corners.
+    pub corner_radius: Value<f64>,
+}
+
+impl Rect {
+    /// Returns true if the rectangle is fixed.
+    pub fn is_fixed(&self) -> bool {
+        self.position.is_fixed() && self.size.is_fixed() && self.corner_radius.is_fixed()
+    }
+
+    /// Evaluates the rectangle at the specified frame.
+    pub fn evaluate(&self, frame: f64) -> kurbo::RoundedRect {
+        let position = self.position.evaluate(frame);
+        let size = self.size.evaluate(frame);
+        let position = Point::new(
+            position.x - size.width * 0.5,
+            position.y - size.height * 0.5,
+        );
+        let radius = self.corner_radius.evaluate(frame);
+        kurbo::RoundedRect::new(
+            position.x,
+            position.y,
+            position.x + size.width,
+            position.y + size.height,
+            radius,
+        )
+    }
+}
+
+/// Animated star or polygon.
+#[derive(Clone, Debug)]
+pub struct Star {
+    pub is_polygon: bool,
+    pub direction: f64,
+    pub position: Value<Point>,
+    pub inner_radius: Value<f64>,
+    pub inner_roundness: Value<f64>,
+    pub outer_radius: Value<f64>,
+    pub outer_roundness: Value<f64>,
+    pub rotation: Value<f64>,
+    pub points: Value<f64>,
+}
+
+// TODO: Use this.
+//impl Star {
+//    pub fn is_fixed(&self) -> bool {
+//        self.position.is_fixed()
+//            && self.inner_radius.is_fixed()
+//            && self.inner_roundness.is_fixed()
+//            && self.outer_radius.is_fixed()
+//            && self.outer_roundness.is_fixed()
+//            && self.rotation.is_fixed()
+//            && self.points.is_fixed()
+//    }
+//}
+
+/// Animated cubic spline.
+#[derive(Clone, Debug)]
+pub struct Spline {
+    /// True if the spline is closed.
+    pub is_closed: bool,
+    /// Collection of times.
+    pub times: Vec<Time>,
+    /// Collection of splines.
+    pub values: Vec<Vec<Point>>,
+}
+
+impl Spline {
+    /// Evaluates the spline at the given frame and emits the elements
+    /// to the specified path.
+    pub fn evaluate(&self, frame: f64, path: &mut Vec<PathEl>) -> bool {
+        let Some(([ix0, ix1], t, _easing, _hold)) = Time::frames_and_weight(&self.times, frame)
+        else {
+            // TODO: evaluate whether hold frame is needed here
+            return false;
+        };
+        let (Some(from), Some(to)) = (self.values.get(ix0), self.values.get(ix1)) else {
+            return false;
+        };
+        (from.as_slice(), to.as_slice(), t).to_path(self.is_closed, path);
+        true
+    }
+}
+
+/// Animated repeater effect.
+#[derive(Clone, Debug)]
+pub struct Repeater {
+    /// Number of times elements should be repeated.
+    pub copies: Value<f64>,
+    /// Offset applied to each element.
+    pub offset: Value<f64>,
+    /// Anchor point.
+    pub anchor_point: Value<Point>,
+    /// Translation.
+    pub position: Value<Point>,
+    /// Rotation in degrees.
+    pub rotation: Value<f64>,
+    /// Scale.
+    pub scale: Value<Vec2>,
+    /// Opacity of the first element.
+    pub start_opacity: Value<f64>,
+    /// Opacity of the last element.
+    pub end_opacity: Value<f64>,
+}
+
+impl Repeater {
+    /// Returns true if the repeater contains no animated properties.
+    pub fn is_fixed(&self) -> bool {
+        self.copies.is_fixed()
+            && self.offset.is_fixed()
+            && self.anchor_point.is_fixed()
+            && self.position.is_fixed()
+            && self.rotation.is_fixed()
+            && self.scale.is_fixed()
+            && self.start_opacity.is_fixed()
+            && self.end_opacity.is_fixed()
+    }
+
+    /// Evaluates the repeater at the specified frame.
+    pub fn evaluate(&self, frame: f64) -> fixed::Repeater {
+        let copies = self.copies.evaluate(frame).round() as usize;
+        let offset = self.offset.evaluate(frame);
+        let anchor_point = self.anchor_point.evaluate(frame);
+        let position = self.position.evaluate(frame);
+        let rotation = self.rotation.evaluate(frame);
+        let scale = self.scale.evaluate(frame);
+        let start_opacity = self.start_opacity.evaluate(frame);
+        let end_opacity = self.end_opacity.evaluate(frame);
+        fixed::Repeater {
+            copies,
+            offset,
+            anchor_point,
+            position,
+            rotation,
+            scale,
+            start_opacity,
+            end_opacity,
+        }
+    }
+
+    /// Converts the animated value to its model representation.
+    pub fn into_model(self) -> super::Repeater {
+        if self.is_fixed() {
+            super::Repeater::Fixed(self.evaluate(0.0))
+        } else {
+            super::Repeater::Animated(self)
+        }
+    }
+}
+
+/// Animated stroke properties.
+#[derive(Clone, Debug)]
+pub struct Stroke {
+    /// Width of the stroke.
+    pub width: Value<f64>,
+    /// Join style.
+    pub join: kurbo::Join,
+    /// Limit for miter joins.
+    pub miter_limit: Option<f64>,
+    /// Cap style.
+    pub cap: kurbo::Cap,
+}
+
+impl Stroke {
+    /// Returns true if the stroke is fixed.
+    pub fn is_fixed(&self) -> bool {
+        self.width.is_fixed()
+    }
+
+    /// Evaluates the stroke at the specified frame.
+    pub fn evaluate(&self, frame: f64) -> kurbo::Stroke {
+        let width = self.width.evaluate(frame);
+        let mut stroke = kurbo::Stroke::new(width)
+            .with_caps(self.cap)
+            .with_join(self.join);
+        if let Some(miter_limit) = self.miter_limit {
+            stroke.miter_limit = miter_limit;
+        }
+        stroke
+    }
+
+    /// Converts the animated value to its model representation.
+    pub fn into_model(self) -> super::Stroke {
+        if self.is_fixed() {
+            super::Stroke::Fixed(self.evaluate(0.0))
+        } else {
+            super::Stroke::Animated(self)
+        }
+    }
+}
+
+/// Animated linear or radial gradient.
+#[derive(Clone, Debug)]
+pub struct Gradient {
+    /// True if the gradient is radial.
+    pub is_radial: bool,
+    /// Starting point.
+    pub start_point: Value<Point>,
+    /// Ending point.
+    pub end_point: Value<Point>,
+    /// Stop offsets and color values.
+    pub stops: super::ColorStops,
+}
+
+impl Gradient {
+    /// Returns true if the value contains no animated properties.
+    pub fn is_fixed(&self) -> bool {
+        self.start_point.is_fixed() && self.end_point.is_fixed() && self.stops.is_fixed()
+    }
+
+    /// Evaluates the animated value at the given frame.
+    pub fn evaluate(&self, frame: f64) -> peniko::Brush {
+        let start = self.start_point.evaluate(frame);
+        let end = self.end_point.evaluate(frame);
+        let stops = self.stops.evaluate(frame).into_owned();
+        if self.is_radial {
+            let radius = (end.to_vec2() - start.to_vec2()).hypot();
+            let mut grad = peniko::Gradient::new_radial(start, radius as f32);
+            grad.stops = stops;
+            grad.into()
+        } else {
+            let mut grad = peniko::Gradient::new_linear(start, end);
+            grad.stops = stops;
+            grad.into()
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ColorStops {
+    pub frames: Vec<Time>,
+    pub values: Vec<Vec<f64>>,
+    pub count: usize,
+}
+
+impl ColorStops {
+    pub fn evaluate(&self, frame: f64) -> fixed::ColorStops {
+        self.evaluate_inner(frame).unwrap_or_default()
+    }
+
+    fn evaluate_inner(&self, frame: f64) -> Option<fixed::ColorStops> {
+        let ([ix0, ix1], t, easing, hold) = Time::frames_and_weight(&self.frames, frame)?;
+
+        let v0 = self.values.get(ix0)?;
+        let v1 = self.values.get(ix1)?;
+
+        let mut stops: fixed::ColorStops = Default::default();
+        for i in 0..self.count {
+            let j = i * 5;
+            let offset = v0.get(j)?.tween(v1.get(j)?, t, &easing);
+            let t = if hold { 0.0 } else { t };
+            let r = v0.get(j + 1)?.tween(v1.get(j + 1)?, t, &easing);
+            let g = v0.get(j + 2)?.tween(v1.get(j + 2)?, t, &easing);
+            let b = v0.get(j + 3)?.tween(v1.get(j + 3)?, t, &easing);
+            let a = v0.get(j + 4)?.tween(v1.get(j + 4)?, t, &easing);
+            let stop = peniko::ColorStop::from((offset as f32, peniko::Color::rgba(r, g, b, a)));
+            stops.push(stop);
+        }
+        Some(stops)
+    }
+}
+
+/// Animated brush.
+#[derive(Clone, Debug)]
+pub enum Brush {
+    /// Solid color.
+    Solid(Value<Color>),
+    /// Gradient color.
+    Gradient(Gradient),
+}
+
+impl Brush {
+    /// Returns true if the value contains no animated properties.
+    pub fn is_fixed(&self) -> bool {
+        match self {
+            Self::Solid(value) => value.is_fixed(),
+            Self::Gradient(value) => value.is_fixed(),
+        }
+    }
+
+    /// Evaluates the animation at the specified time.
+    pub fn evaluate(&self, alpha: f64, frame: f64) -> fixed::Brush {
+        match self {
+            Self::Solid(value) => value.evaluate(frame).with_alpha_factor(alpha as f32).into(),
+            Self::Gradient(value) => value.evaluate(frame),
+        }
+    }
+
+    /// Converts the animated value to its model representation.
+    pub fn into_model(self) -> super::Brush {
+        if self.is_fixed() {
+            super::Brush::Fixed(self.evaluate(1.0, 0.0))
+        } else {
+            super::Brush::Animated(self)
+        }
+    }
+}

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -1,0 +1,86 @@
+// Copyright 2024 the Interpoli Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*!
+Representations of fixed (non-animated) values.
+*/
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+#[allow(unused_imports)]
+use kurbo::common::FloatFuncs as _;
+use kurbo::{Affine, Point, Vec2};
+
+/// Fixed affine transformation.
+pub type Transform = kurbo::Affine;
+
+/// Fixed RGBA color.
+pub type Color = peniko::Color;
+
+/// Fixed color stops.
+pub type ColorStops = peniko::ColorStops;
+
+/// Fixed brush.
+pub type Brush = peniko::Brush;
+
+/// Fixed stroke style.
+pub type Stroke = kurbo::Stroke;
+
+/// Fixed repeater effect.
+#[derive(Clone, Debug)]
+pub struct Repeater {
+    /// Number of times to repeat.
+    pub copies: usize,
+    /// Offset of each subsequent repeated element.
+    pub offset: f64,
+    /// Anchor point.
+    pub anchor_point: Point,
+    /// Translation.
+    pub position: Point,
+    /// Rotation in degrees.
+    pub rotation: f64,
+    /// Scale.
+    pub scale: Vec2,
+    /// Opacity of the first element.
+    pub start_opacity: f64,
+    /// Opacity of the last element.
+    pub end_opacity: f64,
+}
+
+impl Repeater {
+    /// Returns the transform for the given copy index.
+    pub fn transform(&self, index: usize) -> Affine {
+        let t = self.offset + index as f64;
+        Affine::translate((
+            t * self.position.x + self.anchor_point.x,
+            t * self.position.y + self.anchor_point.y,
+        )) * Affine::rotate((t * self.rotation).to_radians())
+            * Affine::scale_non_uniform(
+                (self.scale.x / 100.0).powf(t),
+                (self.scale.y / 100.0).powf(t),
+            )
+            * Affine::translate((-self.anchor_point.x, -self.anchor_point.y))
+    }
+}
+
+// TODO: probably move this to peniko. The better option is to add an alpha
+// parameter to the draw methods in vello. This is already handled at the
+// encoding level.
+pub(crate) fn brush_with_alpha(brush: &Brush, alpha: f64) -> Brush {
+    if alpha == 1.0 {
+        brush.clone()
+    } else {
+        match brush {
+            Brush::Solid(color) => color.with_alpha_factor(alpha as f32).into(),
+            Brush::Gradient(gradient) => Brush::Gradient(peniko::Gradient {
+                kind: gradient.kind,
+                extend: gradient.extend,
+                stops: gradient
+                    .stops
+                    .iter()
+                    .map(|stop| stop.with_alpha_factor(alpha as f32))
+                    .collect(),
+            }),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,105 @@
 #![warn(unused_crate_dependencies)]
 
 //! # Interpoli
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use kurbo::{Affine, PathEl, Point, Shape as _, Size, Vec2};
+use peniko::Color;
+
+mod spline;
+mod value;
+
+pub mod animated;
+pub mod fixed;
+
+pub use value::{Animated, Easing, EasingHandle, Time, Tween, Value, ValueRef};
+
+pub(crate) use spline::SplineToPath;
+
+macro_rules! simple_value {
+    ($name:ident) => {
+        #[allow(clippy::large_enum_variant)]
+        #[derive(Clone, Debug)]
+        pub enum $name {
+            Fixed(fixed::$name),
+            Animated(animated::$name),
+        }
+
+        impl $name {
+            pub fn is_fixed(&self) -> bool {
+                matches!(self, Self::Fixed(_))
+            }
+            pub fn evaluate(&self, frame: f64) -> ValueRef<fixed::$name> {
+                match self {
+                    Self::Fixed(value) => ValueRef::Borrowed(value),
+                    Self::Animated(value) => ValueRef::Owned(value.evaluate(frame)),
+                }
+            }
+        }
+    };
+}
+
+simple_value!(Transform);
+simple_value!(Stroke);
+simple_value!(Repeater);
+simple_value!(ColorStops);
+
+#[derive(Clone, Debug)]
+pub enum Brush {
+    Fixed(fixed::Brush),
+    Animated(animated::Brush),
+}
+
+impl Brush {
+    pub fn is_fixed(&self) -> bool {
+        matches!(self, Self::Fixed(_))
+    }
+
+    pub fn evaluate(&self, alpha: f64, frame: f64) -> ValueRef<fixed::Brush> {
+        match self {
+            Self::Fixed(value) => {
+                if alpha == 1.0 {
+                    ValueRef::Borrowed(value)
+                } else {
+                    ValueRef::Owned(fixed::brush_with_alpha(value, alpha))
+                }
+            }
+            Self::Animated(value) => ValueRef::Owned(value.evaluate(alpha, frame)),
+        }
+    }
+}
+
+impl Default for Transform {
+    fn default() -> Self {
+        Self::Fixed(Affine::IDENTITY)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Geometry {
+    Fixed(Vec<PathEl>),
+    Rect(animated::Rect),
+    Ellipse(animated::Ellipse),
+    Spline(animated::Spline),
+}
+
+impl Geometry {
+    pub fn evaluate(&self, frame: f64, path: &mut Vec<PathEl>) {
+        match self {
+            Self::Fixed(value) => {
+                path.extend_from_slice(value);
+            }
+            Self::Rect(value) => {
+                path.extend(value.evaluate(frame).path_elements(0.1));
+            }
+            Self::Ellipse(value) => {
+                path.extend(value.evaluate(frame).path_elements(0.1));
+            }
+            Self::Spline(value) => {
+                value.evaluate(frame, path);
+            }
+        }
+    }
+}

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 the Interpoli Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+use kurbo::{PathEl, Point};
+
+/// Helper trait for converting cubic splines to paths.
+pub trait SplineToPath {
+    fn get(&self, index: usize) -> Point;
+    fn len(&self) -> usize;
+
+    fn to_path(&self, is_closed: bool, path: &mut Vec<PathEl>) -> Option<()> {
+        use PathEl::*;
+        if self.len() == 0 {
+            return None;
+        }
+        path.push(MoveTo(self.get(0)));
+        let n_vertices = self.len() / 3;
+        let mut add_element = |from_vertex, to_vertex| {
+            let from_index = 3 * from_vertex;
+            let to_index = 3 * to_vertex;
+            let p0: Point = self.get(from_index);
+            let p1: Point = self.get(to_index);
+            let mut c0: Point = self.get(from_index + 2);
+            c0.x += p0.x;
+            c0.y += p0.y;
+            let mut c1: Point = self.get(to_index + 1);
+            c1.x += p1.x;
+            c1.y += p1.y;
+            if c0 == p0 && c1 == p1 {
+                path.push(LineTo(p1));
+            } else {
+                path.push(CurveTo(c0, c1, p1));
+            }
+        };
+        for i in 1..n_vertices {
+            add_element(i - 1, i);
+        }
+        if is_closed && n_vertices != 0 {
+            add_element(n_vertices - 1, 0);
+            path.push(ClosePath);
+        }
+        Some(())
+    }
+}
+
+/// Converts a static spline to a path.
+impl SplineToPath for &'_ [Point] {
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn get(&self, index: usize) -> Point {
+        self[index]
+    }
+}
+
+/// Produces a path by lerping between two sets of points.
+impl SplineToPath for (&'_ [Point], &'_ [Point], f64) {
+    fn len(&self) -> usize {
+        self.0.len().min(self.1.len())
+    }
+
+    fn get(&self, index: usize) -> Point {
+        // TODO: This definitely shouldn't be a lerp
+        self.0[index].lerp(self.1[index], self.2)
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,215 @@
+// Copyright 2024 the Interpoli Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec::Vec;
+use peniko::{self, kurbo};
+
+/// Fixed or animated value.
+#[derive(Clone, Debug)]
+pub enum Value<T: Tween> {
+    /// Fixed value.
+    Fixed(T),
+    /// Animated value.
+    Animated(Animated<T>),
+}
+
+impl<T: Tween> Value<T> {
+    /// Returns true if the value is fixed.
+    pub fn is_fixed(&self) -> bool {
+        matches!(self, Self::Fixed(_))
+    }
+
+    /// Returns the value at a specified frame.
+    pub fn evaluate(&self, frame: f64) -> T {
+        match self {
+            Self::Fixed(fixed) => fixed.clone(),
+            Self::Animated(animated) => animated.evaluate(frame),
+        }
+    }
+}
+
+impl<T: Tween + Default> Default for Value<T> {
+    fn default() -> Self {
+        Self::Fixed(T::default())
+    }
+}
+
+/// Borrowed or owned value.
+#[derive(Clone, Debug)]
+pub enum ValueRef<'a, T> {
+    Borrowed(&'a T),
+    Owned(T),
+}
+
+impl<'a, T> AsRef<T> for ValueRef<'a, T> {
+    fn as_ref(&self) -> &T {
+        match self {
+            Self::Borrowed(value) => value,
+            Self::Owned(value) => value,
+        }
+    }
+}
+
+impl<'a, T: Clone> ValueRef<'a, T> {
+    pub fn into_owned(self) -> T {
+        match self {
+            Self::Borrowed(value) => value.clone(),
+            Self::Owned(value) => value,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Easing {
+    pub o: EasingHandle,
+    pub i: EasingHandle,
+}
+
+impl Easing {
+    pub const LERP: Easing = Easing {
+        o: EasingHandle { x: 0.0, y: 0.0 },
+        i: EasingHandle { x: 1.0, y: 1.0 },
+    };
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct EasingHandle {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// Time for a particular keyframe, represented as a frame number.
+#[derive(Copy, Clone, Debug)]
+pub struct Time {
+    /// Frame number.
+    pub frame: f64,
+    /// Easing tangent going into the next keyframe
+    pub in_tangent: Option<EasingHandle>,
+    /// Easing tangent leaving the current keyframe
+    pub out_tangent: Option<EasingHandle>,
+    /// Whether it's a hold frame.
+    pub hold: bool,
+}
+
+impl Time {
+    /// Returns the frame indices and interpolation weight for the given frame,
+    /// and whether to hold the frame
+    pub(crate) fn frames_and_weight(
+        times: &[Time],
+        frame: f64,
+    ) -> Option<([usize; 2], f64, Easing, bool)> {
+        if times.is_empty() {
+            return None;
+        }
+        use core::cmp::Ordering::*;
+        let ix = match times.binary_search_by(|x| {
+            if x.frame < frame {
+                Less
+            } else if x.frame > frame {
+                Greater
+            } else {
+                Equal
+            }
+        }) {
+            Ok(ix) => ix,
+            Err(ix) => ix.saturating_sub(1),
+        };
+        let ix0 = ix.min(times.len() - 1);
+        let ix1 = (ix0 + 1).min(times.len() - 1);
+
+        let t0 = times[ix0];
+        let t1 = times[ix1];
+        let (t0_ox, t0_oy) = t0.out_tangent.map(|o| (o.x, o.y)).unwrap_or((0.0, 0.0));
+        let (t1_ix, t1_iy) = t1.in_tangent.map(|i| (i.x, i.y)).unwrap_or((1.0, 1.0));
+        let easing = Easing {
+            o: EasingHandle { x: t0_ox, y: t0_oy },
+            i: EasingHandle { x: t1_ix, y: t1_iy },
+        };
+        let hold = t0.hold;
+        let t = (frame - t0.frame) / (t1.frame - t0.frame);
+        Some(([ix0, ix1], t.clamp(0.0, 1.0), easing, hold))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Animated<T: Tween> {
+    pub times: Vec<Time>,
+    pub values: Vec<T>,
+}
+
+impl<T: Tween> Animated<T> {
+    /// Returns the value at the specified frame.
+    pub fn evaluate(&self, frame: f64) -> T {
+        self.evaluate_inner(frame).unwrap_or_default()
+    }
+
+    fn evaluate_inner(&self, frame: f64) -> Option<T> {
+        let ([ix0, ix1], t, easing, hold) = Time::frames_and_weight(&self.times, frame)?;
+        let t = if hold { 0.0 } else { t };
+
+        let v1 = self.values.get(ix0)?;
+        let v2 = self.values.get(ix1)?;
+
+        Some(v1.tween(v2, t, &easing))
+    }
+}
+
+/// Something that can be interpolated with an easing function.
+pub trait Tween: Clone + Default {
+    fn tween(&self, other: &Self, t: f64, easing: &Easing) -> Self;
+}
+
+impl Tween for f64 {
+    fn tween(&self, other: &Self, t: f64, _easing: &Easing) -> Self {
+        // TODO: We are enforcing linear interpolation for now, but a decent amount of work is done for easings.
+        keyframe::ease(keyframe::functions::Linear, *self, *other, t)
+
+        // FIXME: Hopefully we can finish this up one day!
+        //keyframe::ease(
+        //    keyframe::functions::BezierCurve::from(
+        //        keyframe::mint::Vector2::from_slice(&[easing.o.x, easing.o.y]),
+        //        keyframe::mint::Vector2::from_slice(&[easing.i.x, easing.i.y]),
+        //    ),
+        //    *self,
+        //    *other,
+        //    t,
+        //)
+    }
+}
+
+impl Tween for kurbo::Point {
+    fn tween(&self, other: &Self, t: f64, easing: &Easing) -> Self {
+        Self::new(
+            self.x.tween(&other.x, t, easing),
+            self.y.tween(&other.y, t, easing),
+        )
+    }
+}
+
+impl Tween for kurbo::Vec2 {
+    fn tween(&self, other: &Self, t: f64, easing: &Easing) -> Self {
+        Self::new(
+            self.x.tween(&other.x, t, easing),
+            self.y.tween(&other.y, t, easing),
+        )
+    }
+}
+
+impl Tween for kurbo::Size {
+    fn tween(&self, other: &Self, t: f64, easing: &Easing) -> Self {
+        Self::new(
+            self.width.tween(&other.width, t, easing),
+            self.height.tween(&other.height, t, easing),
+        )
+    }
+}
+
+impl Tween for peniko::Color {
+    fn tween(&self, other: &Self, t: f64, easing: &Easing) -> Self {
+        let r = (self.r as f64 / 255.0).tween(&(other.r as f64 / 255.0), t, easing);
+        let g = (self.g as f64 / 255.0).tween(&(other.g as f64 / 255.0), t, easing);
+        let b = (self.b as f64 / 255.0).tween(&(other.b as f64 / 255.0), t, easing);
+        let a = (self.a as f64 / 255.0).tween(&(other.a as f64 / 255.0), t, easing);
+        peniko::Color::rgba(r, g, b, a)
+    }
+}


### PR DESCRIPTION
Initial code from Velato

This is the initial code from Velato's `src/runtime/model` but with some aspects removed, mainly the `Layer` concept: `Content`, `Draw`, `GroupTransform`, `Layer`, `Mask`, `Matte`, `Shape`.

Minimal changes have been made to get it to compile and be free of lint warnings by disabling the lints.

Subsequent changes will address lints and perform further cleanups and changes to prepare for an initial release.