### PR TITLE
`Composition`: Use `hashbrown::HashMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +145,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hexf-parse"
@@ -148,6 +170,7 @@ dependencies = [
 name = "interpoli"
 version = "0.1.0"
 dependencies = [
+ "hashbrown",
  "keyframe",
  "kurbo",
  "peniko",
@@ -239,6 +262,12 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "parking_lot"
@@ -458,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,3 +573,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
+hashbrown = "0.14.5"
 keyframe = { version = "1.1.1", default-features = false }
 kurbo = { version = "0.11", default-features = false }
 peniko = { version = "0.1.1", default-features = false }

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -5,8 +5,7 @@ use alloc::{string::String, vec::Vec};
 use core::ops::Range;
 use kurbo::{PathEl, Shape as _};
 
-#[cfg(feature = "std")]
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use crate::{animated, Brush, Repeater, Stroke, Transform, Value};
 
@@ -22,7 +21,6 @@ pub struct Composition {
     /// Height of the animation.
     pub height: usize,
     /// Precomposed layers that may be instanced.
-    #[cfg(feature = "std")]
     pub assets: HashMap<String, Vec<Layer>>,
     /// Collection of layers.
     pub layers: Vec<Layer>,


### PR DESCRIPTION
`hashbrown::HashMap` supports use in `no_std` environments (with the use of `alloc`). This keeps the API the same between `no_std` and `std` environments.